### PR TITLE
Add default make target and output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 *.png
 *.svg
 !*.ink.svg
+
+# generated files
+output/

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,16 @@
 PIXEL=500
 
-clean:
-	# add Python script
-upload:
-	git add --all
-	git commit
+all: clean generate
 
-generate:
-	inkscape --export-plain-svg --export-text-to-path
-	inkscape --export-png
+clean:
+	rm -rf output
+
+generate: export-svg export-png
 
 export-svg:
 	inkscape --export-plain-svg --export-text-to-path
 
 export-png:
-	inkscape --export-png logo$(PIXEL)px.png --export-height=$(PIXEL) src/base.ink.svg
+	mkdir output
+	inkscape --export-png output/logo$(PIXEL)px.png --export-height=$(PIXEL) src/base.ink.svg
 


### PR DESCRIPTION
A new first target (default when just calling make) called 'all'
will run clean and generate. Generate will call all steps to generate
graphics. Everything will be saved into the output directory. Also
fixes #12