### PR TITLE
Fix Makefile failing when output dir exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ clean:
 generate: export-svg export-png
 
 export-svg:
-	mkdir output
+	mkdir -p output
 	inkscape --export-plain-svg=output/logo.svg --export-text-to-path src/base.ink.svg
 
 export-png:
-	mkdir output
+	mkdir -p output
 	inkscape --export-png output/logo$(PIXEL)px.png --export-height=$(PIXEL) src/base.ink.svg
 


### PR DESCRIPTION
Make-ing the project did not work for me, since without the -p option the mkdir command complains that there is already a directory, thus failing the rest of the make process. So, once you build one target after a clean, the next will fail unnecessarily. This fixes that, without ignoring other errors that could arise from mkdir.